### PR TITLE
fix: pick idle judge machine, skip busy ones

### DIFF
--- a/submissions/judge_load_balancer.py
+++ b/submissions/judge_load_balancer.py
@@ -67,8 +67,7 @@ class JudgeLoadBalancer:
         return healthy_machines
 
     def _get_queue_length(self, machine):
-        """Get number of pending/enqueued jobs on this machine's queue.
-        Returns 0 if the queue can't be reached (treat as overloaded to avoid)."""
+        """Get number of pending/enqueued jobs on this machine's queue."""
         try:
             import redis
             r = redis.Redis(
@@ -78,11 +77,86 @@ class JudgeLoadBalancer:
                 socket_connect_timeout=3,
                 socket_timeout=3,
             )
-            # RQ stores jobs under rq:queue:<name>
             return r.llen(f"rq:queue:{machine['queue']}")
         except Exception:
-            # Can't reach Redis — treat as heavily loaded so we skip it
             return 9999
+
+    def _get_busy_count(self, machine):
+        """Get number of jobs currently being executed by this machine's worker."""
+        try:
+            import redis
+            r = redis.Redis(
+                host=machine['host'],
+                port=machine['port'],
+                db=machine['db'],
+                socket_connect_timeout=3,
+                socket_timeout=3,
+            )
+            return int(r.get(f"judge:busy:{machine['name']}") or 0)
+        except Exception:
+            return 9999
+
+    def _incr_busy(self, machine):
+        """Increment busy count when a job is dispatched to this machine."""
+        try:
+            import redis
+            r = redis.Redis(
+                host=machine['host'],
+                port=machine['port'],
+                db=machine['db'],
+                socket_connect_timeout=3,
+                socket_timeout=3,
+            )
+            r.incr(f"judge:busy:{machine['name']}")
+            r.expire(f"judge:busy:{machine['name']}", 3600)
+        except Exception:
+            pass
+
+    def _decr_busy(self, machine):
+        """Decrement busy count when a job finishes on this machine."""
+        try:
+            import redis
+            r = redis.Redis(
+                host=machine['host'],
+                port=machine['port'],
+                db=machine['db'],
+                socket_connect_timeout=3,
+                socket_timeout=3,
+            )
+            val = r.decr(f"judge:busy:{machine['name']}")
+            if val <= 0:
+                r.delete(f"judge:busy:{machine['name']}")
+        except Exception:
+            pass
+
+    def _set_submission_machine(self, submission_id, machine_name):
+        """Record which machine is processing a submission."""
+        try:
+            cache.set(f'judge:sub_machine:{submission_id}', machine_name, 3600)
+        except Exception:
+            pass
+
+    def _get_and_clear_submission_machine(self, submission_id):
+        """Get and clear the machine assignment for a submission."""
+        try:
+            key = f'judge:sub_machine:{submission_id}'
+            machine_name = cache.get(key)
+            if machine_name:
+                cache.delete(key)
+            return machine_name
+        except Exception:
+            return None
+
+    def release_machine(self, submission_id):
+        """Called by the task when judging completes to decrement busy count."""
+        machine_name = self._get_and_clear_submission_machine(submission_id)
+        if machine_name:
+            # Find the machine config to get host/port/db
+            for m in self.machines:
+                if m['name'] == machine_name:
+                    self._decr_busy(m)
+                    logger.debug(f'Released machine {machine_name} for submission {submission_id}')
+                    return
 
     def select_machine(self):
         """Select the least-loaded healthy judge machine.
@@ -96,12 +170,14 @@ class JudgeLoadBalancer:
             logger.warning('No healthy judge machines available, falling back to default queue')
             return None
 
-        # Query queue lengths for all healthy machines
+        # Query queue lengths AND busy counts for all healthy machines
         machine_loads = []
         for m in healthy_machines:
             qlen = self._get_queue_length(m)
-            machine_loads.append((qlen, m))
-            logger.debug(f'  {m["name"]}: {qlen} pending jobs')
+            busy = self._get_busy_count(m)
+            total_load = qlen + busy  # pending + currently executing
+            machine_loads.append((total_load, m))
+            logger.debug(f'  {m["name"]}: queue={qlen}, busy={busy}, total={total_load}')
 
         # Sort by queue length (ascending — less loaded first)
         machine_loads.sort(key=lambda x: x[0])

--- a/submissions/judge_load_balancer.py
+++ b/submissions/judge_load_balancer.py
@@ -66,32 +66,68 @@ class JudgeLoadBalancer:
         
         return healthy_machines
 
+    def _get_queue_length(self, machine):
+        """Get number of pending/enqueued jobs on this machine's queue.
+        Returns 0 if the queue can't be reached (treat as overloaded to avoid)."""
+        try:
+            import redis
+            r = redis.Redis(
+                host=machine['host'],
+                port=machine['port'],
+                db=machine['db'],
+                socket_connect_timeout=3,
+                socket_timeout=3,
+            )
+            # RQ stores jobs under rq:queue:<name>
+            return r.llen(f"rq:queue:{machine['queue']}")
+        except Exception:
+            # Can't reach Redis — treat as heavily loaded so we skip it
+            return 9999
+
     def select_machine(self):
-        """Select a judge machine using weighted round-robin."""
+        """Select the least-loaded healthy judge machine.
+        Machines with fewer pending jobs are preferred.
+        Among equally-loaded machines, weight is used for tie-breaking."""
         if not self.multi_judge_enabled:
             return None
 
         healthy_machines = self.get_healthy_machines()
-        
         if not healthy_machines:
             logger.warning('No healthy judge machines available, falling back to default queue')
             return None
 
-        # Weighted random selection
-        total_weight = sum(m.get('weight', 1) for m in healthy_machines)
-        if total_weight == 0:
-            return random.choice(healthy_machines)
+        # Query queue lengths for all healthy machines
+        machine_loads = []
+        for m in healthy_machines:
+            qlen = self._get_queue_length(m)
+            machine_loads.append((qlen, m))
+            logger.debug(f'  {m["name"]}: {qlen} pending jobs')
 
+        # Sort by queue length (ascending — less loaded first)
+        machine_loads.sort(key=lambda x: x[0])
+
+        # Group machines with the same (minimum) queue length
+        min_load = machine_loads[0][0]
+        candidates = [m for qlen, m in machine_loads if qlen == min_load]
+
+        # If only one candidate, return it
+        if len(candidates) == 1:
+            logger.info(f'Selected judge machine: {candidates[0]["name"]} '
+                        f'(load: {min_load}, only idle candidate)')
+            return candidates[0]
+
+        # Tie-break among equally-loaded machines using weighted random
+        total_weight = sum(m.get('weight', 1) for m in candidates)
         rand = random.uniform(0, total_weight)
-        current_weight = 0
-        
-        for machine in healthy_machines:
-            current_weight += machine.get('weight', 1)
-            if rand <= current_weight:
-                logger.info(f'Selected judge machine: {machine["name"]}')
-                return machine
+        current = 0
+        for m in candidates:
+            current += m.get('weight', 1)
+            if rand <= current:
+                logger.info(f'Selected judge machine: {m["name"]} '
+                            f'(load: {min_load}, weighted among {len(candidates)} candidates)')
+                return m
 
-        return healthy_machines[-1]  # Fallback to last machine
+        return candidates[-1]
 
     def get_queue_for_machine(self, machine):
         """Get RQ queue configuration for a specific judge machine."""

--- a/submissions/judge_queue.py
+++ b/submissions/judge_queue.py
@@ -20,6 +20,9 @@ def enqueue_judge(submission_id):
             
             if machine:
                 try:
+                    # Increment busy count and record machine assignment
+                    load_balancer._incr_busy(machine)
+                    load_balancer._set_submission_machine(submission_id, machine['name'])
                     # Enqueue to specific judge machine's queue
                     queue_config = load_balancer.get_queue_for_machine(machine)
                     queue = get_queue(queue_config['name'])

--- a/submissions/tasks.py
+++ b/submissions/tasks.py
@@ -46,6 +46,13 @@ def judge_submission_task(submission_id):
         submission.status = 'Runtime Error'
         submission.save()
         return None
+    finally:
+        # Release the judge machine regardless of outcome
+        try:
+            from submissions.judge_load_balancer import load_balancer
+            load_balancer.release_machine(submission_id)
+        except Exception as e:
+            logger.warning(f'Error releasing machine for submission {submission_id}: {e}')
 
     # Clear relevant caches
     try:


### PR DESCRIPTION
load balancer now checks if a machine is actually free before picking it.

before: only looked at queue length (pending jobs in Redis). if a machine was running a job but had empty queue, it could still get picked.

now: also tracks `busy` count — incremented when dispatching, decremented when the task finishes. total load = queue + busy. idle machines always win.

- `_get_busy_count` — reads `judge:busy:<name>` from Redis
- `_incr_busy` / `_decr_busy` — called on dispatch / task completion
- `release_machine` — called in task `finally` block, never leaks