### PR TITLE
fix CI: move env to top level

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  DJANGO_SECRET_KEY: ci-secret-key-not-for-production
+  USE_SQLITE: 'true'
+  DJANGO_DEBUG: 'true'
+  OJ_DOCKER_ENABLED: 'false'
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -34,19 +40,9 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run migrations
-        env:
-          DJANGO_SECRET_KEY: ci-secret-key-not-for-production
-          USE_SQLITE: 'true'
-          DJANGO_DEBUG: 'true'
-          OJ_DOCKER_ENABLED: 'false'
         run: python manage.py migrate
 
       - name: Run tests
-        env:
-          DJANGO_SECRET_KEY: ci-secret-key-not-for-production
-          USE_SQLITE: 'true'
-          DJANGO_DEBUG: 'true'
-          OJ_DOCKER_ENABLED: 'false'
         run: python -Wa manage.py test --verbosity=2
 
   lint:


### PR DESCRIPTION
was trying to connect to PostgreSQL because per-step env vars in multi-line `run: |` blocks weren't being picked up. moved all env vars to workflow top-level — now SQLite is used correctly.